### PR TITLE
Fix none type error

### DIFF
--- a/listurl.py
+++ b/listurl.py
@@ -309,7 +309,7 @@ def extract_urls(page_data, page_url):
                 # Also list the possible POST parameters
                 params = []
                 for inp in link.find_all("input"):
-                    if inp.get("name"):
+                    if inp.get("name") and inp.get("type") is not None:
                         params.append(InputParameter(inp.get("name"), inp.get("value"), inp.get("type")))
                 if params:
                     grabbed_url.parameters = params


### PR DESCRIPTION
Hi ! Me again :) 
This PR tries to fix the None type which lead to a crash.

**BEFORE**
```
$ ./listurl.py -u https://google.com
Traceback (most recent call last):
  File "./listurl.py", line 467, in <module>
    main()
  File "./listurl.py", line 387, in main
    init.run()  # Do not start a thread, just run synchronously for the first request.
  File "./listurl.py", line 351, in run
    urls = extract_urls(r.text, url.url)
  File "./listurl.py", line 313, in extract_urls
    params.append(InputParameter(inp.get("name"), inp.get("value"), inp.get("type")))
  File "./listurl.py", line 169, in __init__
    self.type = param_type.upper()
AttributeError: 'NoneType' object has no attribute 'upper'
```
**AFTER**
```
$ ./listurl.py -u https://google.com
[*] Started crawling at depth 1.     
[*] Started crawling at depth 2.
...
```

